### PR TITLE
Allow blank units

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -1,10 +1,10 @@
 class Measure < ApplicationRecord
   validates :quantity, presence: true
-  validates :unit_id, presence: true
+  validates :unit_id, presence: true, allow_blank: true
   validates :ingredient_id, presence: true
   validates :recipe_id, presence: true
 
-  belongs_to :unit
+  belongs_to :unit, optional: true
   belongs_to :ingredient
   belongs_to :recipe
 end
@@ -15,7 +15,7 @@ end
 #
 #  id            :bigint           not null, primary key
 #  quantity      :integer
-#  unit_id       :bigint           not null
+#  unit_id       :bigint
 #  ingredient_id :bigint           not null
 #  recipe_id     :bigint           not null
 #  created_at    :datetime         not null

--- a/app/views/measures/new.html.erb
+++ b/app/views/measures/new.html.erb
@@ -9,7 +9,7 @@
 
     <div>
       <%= f.label :unit %>
-      <%= f.select :unit_id, options_for_select(Unit.all.collect { |u| [ u.name, u.id ] }) %>
+      <%= f.collection_select :unit_id, Unit.all.alphabetize, :id, :name, { include_blank: true } %>
     </div>
 
     <div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -7,7 +7,7 @@
       <% @recipe.measures.each do |measure| %>
         <li>
           <%= measure.quantity %>
-          <%= measure.unit.name %>
+          <%= measure.unit.name if measure.unit %>
           <%= measure.ingredient.name %>
           <%= link_to "delete", measure_path(measure), method: :delete %>
         </li>

--- a/db/migrate/20200711022620_change_unit_column_null.rb
+++ b/db/migrate/20200711022620_change_unit_column_null.rb
@@ -1,0 +1,5 @@
+class ChangeUnitColumnNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :measures, :unit_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_03_223304) do
+ActiveRecord::Schema.define(version: 2020_07_11_022620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2020_07_03_223304) do
 
   create_table "measures", force: :cascade do |t|
     t.integer "quantity"
-    t.bigint "unit_id", null: false
+    t.bigint "unit_id"
     t.bigint "ingredient_id", null: false
     t.bigint "recipe_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  quantity      :integer
-#  unit_id       :bigint           not null
+#  unit_id       :bigint
 #  ingredient_id :bigint           not null
 #  recipe_id     :bigint           not null
 #  created_at    :datetime         not null


### PR DESCRIPTION
- Allow user to pick a blank unit when creating a recipe measure

`1 avocado` vs. `1 clove garlic`