### PR TITLE
Display quantities in fractions

### DIFF
--- a/app/models/display_measure.rb
+++ b/app/models/display_measure.rb
@@ -14,7 +14,17 @@ class DisplayMeasure
   end
 
   def quantity
-    @quantity
+    if @unit.name == 'cup' || @unit.name == 'teaspoon' || @unit.name == 'tablespoon'
+      if @quantity < 1
+        @quantity.to_s.to_r
+      elsif (@quantity % 2).zero? || @quantity == 1
+        @quantity.to_i
+      else
+        "#{@quantity.to_i} #{@quantity.to_s.to_r - @quantity.to_i}"
+      end
+    else
+      @quantity.to_i
+    end
   end
 
   def unit


### PR DESCRIPTION
- Display quantities as fractions for the units cup, tablespoon, and teaspoon.
- Don't display fractions for the other units
- Don't display `.0`

`
4.5 cups => 4 1/2 cup
4.0 cups => 4 cups
0.75 cup => 3/4 cup
300.0 milliliter => 300 mililiter
`